### PR TITLE
pin dependency markupsafe to 2.0.1

### DIFF
--- a/docker/dbt.Dockerfile
+++ b/docker/dbt.Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get update \
     # update pip
     && pip install -U pip
 
-RUN pip install dbt==0.19.1
+RUN pip install \
+    markupsafe==2.0.1 \
+    dbt==0.19.1
 
 ENV DBT_PROFILES_DIR .profiles
 ENTRYPOINT [ "dbt" ]


### PR DESCRIPTION
pins markupsafe to 2.0.1.

an update to markupsafe breaks dbt installation due to removal of function `soft_unicode`

error message:

```
 File "/usr/local/lib/python3.8/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.8/site-packages/markupsafe/__init__.py)
ERROR: 1
```